### PR TITLE
Add recursive scale tunnel effect script for After Effects

### DIFF
--- a/ae/recursive_scale_tunnel.jsx
+++ b/ae/recursive_scale_tunnel.jsx
@@ -1,0 +1,351 @@
+#target aftereffects
+/*
+ * Recursive Scale Tunnel
+ * Takes a single selected layer, duplicates it at progressively smaller scales
+ * to create a tunnel/zoom effect. Optionally creates a controller null for
+ * animated offset of the entire tunnel.
+ *
+ * Usage: Run from File > Scripts > Run Script File...
+ */
+
+(function() {
+
+    var NAME_PREFIX = "RST__";
+    var CTRL_NAME = "Tunnel Offset Controller";
+
+    // ========== UTILITY FUNCTIONS ==========
+
+    function startsWith(str, prefix) {
+        return str && str.indexOf(prefix) === 0;
+    }
+
+    function parsePositiveFloat(value) {
+        var n = parseFloat(value);
+        if (isNaN(n) || n <= 0) return null;
+        return n;
+    }
+
+    function zeroPad(num, digits) {
+        var s = String(num);
+        while (s.length < digits) {
+            s = "0" + s;
+        }
+        return s;
+    }
+
+    function isResizableLayer(layer) {
+        if (layer.locked) return false;
+        if (layer.nullLayer) return false;
+        if (layer.adjustmentLayer) return false;
+
+        if (layer instanceof CameraLayer) return false;
+        if (layer instanceof LightLayer) return false;
+        if (layer instanceof ShapeLayer) return false;
+        if (layer instanceof TextLayer) return false;
+
+        try {
+            var w = layer.source.width;
+            var h = layer.source.height;
+            if (!w || !h) return false;
+        } catch (e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    function hasScaleKeyframes(layer) {
+        try {
+            return layer.property("Transform").property("Scale").numKeys > 0;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    // ========== DIALOG ==========
+
+    function showDialog() {
+        var dlg = new Window("dialog", "Recursive Scale Tunnel");
+
+        dlg.add("statictext", undefined, "Step size (pixels):");
+        var stepInput = dlg.add("edittext", undefined, "100");
+        stepInput.characters = 10;
+
+        dlg.add("statictext", undefined, "Minimum size (pixels):");
+        var minInput = dlg.add("edittext", undefined, "240");
+        minInput.characters = 10;
+
+        var dimPanel = dlg.add("panel", undefined, "Reference Dimension");
+        dimPanel.orientation = "row";
+        dimPanel.alignment = "left";
+        var matchWidth = dimPanel.add("radiobutton", undefined, "Width");
+        var matchHeight = dimPanel.add("radiobutton", undefined, "Height");
+        matchWidth.value = true;
+
+        var ctrlCheck = dlg.add("checkbox", undefined, "Create offset controller null");
+
+        var btnGroup = dlg.add("group");
+        var okBtn = btnGroup.add("button", undefined, "Apply");
+        var cancelBtn = btnGroup.add("button", undefined, "Cancel");
+
+        okBtn.onClick = function() { dlg.close(1); };
+        cancelBtn.onClick = function() { dlg.close(0); };
+
+        stepInput.active = true;
+
+        if (dlg.show() !== 1) {
+            return null;
+        }
+
+        var step = parsePositiveFloat(stepInput.text);
+        if (step === null) {
+            alert("Please enter a positive number for step size.");
+            return null;
+        }
+
+        var minSize = parsePositiveFloat(minInput.text);
+        if (minSize === null) {
+            alert("Please enter a positive number for minimum size.");
+            return null;
+        }
+
+        return {
+            step: step,
+            minSize: minSize,
+            useWidth: matchWidth.value,
+            createController: ctrlCheck.value
+        };
+    }
+
+    // ========== CORE FUNCTIONS ==========
+
+    function getExistingTunnelLayers(comp) {
+        var layers = [];
+        for (var i = 1; i <= comp.numLayers; i++) {
+            var layer = comp.layer(i);
+            if (startsWith(layer.name, NAME_PREFIX)) {
+                layers.push(layer);
+            }
+        }
+        return layers;
+    }
+
+    function removeExistingTunnelLayers(comp, excludeLayer) {
+        for (var i = comp.numLayers; i >= 1; i--) {
+            var layer = comp.layer(i);
+            if (layer === excludeLayer) continue;
+            if (startsWith(layer.name, NAME_PREFIX)) {
+                layer.remove();
+            }
+        }
+        // Also remove controller null if it exists
+        for (var j = comp.numLayers; j >= 1; j--) {
+            var lyr = comp.layer(j);
+            if (lyr === excludeLayer) continue;
+            if (lyr.name === CTRL_NAME) {
+                lyr.remove();
+                break;
+            }
+        }
+    }
+
+    function getRenderedDimension(layer, useWidth) {
+        var scaleVal = layer.property("Transform").property("Scale").value;
+        var sourceDim = useWidth ? layer.source.width : layer.source.height;
+        var scaleAxis = useWidth ? scaleVal[0] : scaleVal[1];
+        return {
+            rendered: sourceDim * scaleAxis / 100,
+            sourceDim: sourceDim
+        };
+    }
+
+    function createTunnel(comp, sourceLayer, settings) {
+        var dimInfo = getRenderedDimension(sourceLayer, settings.useWidth);
+        var renderedDim = dimInfo.rendered;
+        var sourceDim = dimInfo.sourceDim;
+
+        var count = Math.floor((renderedDim - settings.minSize) / settings.step);
+
+        if (count <= 0) {
+            alert(
+                "No duplicates needed.\n\n" +
+                "Current rendered " + (settings.useWidth ? "width" : "height") + ": " + Math.round(renderedDim) + " px\n" +
+                "Minimum size: " + settings.minSize + " px\n" +
+                "Step: " + settings.step + " px\n\n" +
+                "The step size is larger than the available range (" + Math.round(renderedDim - settings.minSize) + " px).\n" +
+                "Try a smaller step or lower minimum size."
+            );
+            return null;
+        }
+
+        if (count > 50) {
+            var proceed = confirm(
+                "This will create " + count + " duplicate layers and may run slowly.\nContinue?"
+            );
+            if (!proceed) return null;
+        }
+
+        var is3D = sourceLayer.threeDLayer;
+        var padDigits = String(count).length;
+        if (padDigits < 2) padDigits = 2;
+
+        // Strip existing prefix and suffix from re-runs to avoid double-prefixing
+        var baseName = sourceLayer.name;
+        if (startsWith(baseName, NAME_PREFIX)) {
+            baseName = baseName.substring(NAME_PREFIX.length);
+        }
+        var origSuffix = " (original)";
+        if (baseName.length > origSuffix.length &&
+            baseName.substring(baseName.length - origSuffix.length) === origSuffix) {
+            baseName = baseName.substring(0, baseName.length - origSuffix.length);
+        }
+
+        // Rename original layer with prefix for re-run detection
+        sourceLayer.name = NAME_PREFIX + baseName + " (original)";
+
+        var duplicates = [];
+
+        // Create duplicates from smallest to largest so smallest ends up on top
+        for (var i = count; i >= 1; i--) {
+            var dup = sourceLayer.duplicate();
+            var newRendered = renderedDim - (i * settings.step);
+            var scalePct = (newRendered / sourceDim) * 100;
+
+            if (is3D) {
+                dup.property("Transform").property("Scale").setValue([scalePct, scalePct, scalePct]);
+            } else {
+                dup.property("Transform").property("Scale").setValue([scalePct, scalePct]);
+            }
+
+            dup.name = NAME_PREFIX + baseName + " " + zeroPad(i, padDigits);
+            duplicates.push(dup);
+        }
+
+        return {
+            duplicates: duplicates,
+            count: count,
+            smallestScale: ((renderedDim - count * settings.step) / sourceDim) * 100,
+            largestScale: ((renderedDim - settings.step) / sourceDim) * 100
+        };
+    }
+
+    function createControllerNull(comp, sourceLayer, duplicates) {
+        var ctrl = comp.layers.addNull();
+        ctrl.name = CTRL_NAME;
+
+        // Position at comp center
+        ctrl.property("Transform").property("Position").setValue([comp.width / 2, comp.height / 2]);
+
+        // Move to top of layer stack
+        ctrl.moveTo(1);
+
+        // Build offset expression
+        var exp = [
+            'var ctrl = thisComp.layer("' + CTRL_NAME + '");',
+            'var offset = ctrl.transform.position - [thisComp.width/2, thisComp.height/2];',
+            'value + offset;'
+        ].join("\n");
+
+        // Apply to all duplicates
+        for (var i = 0; i < duplicates.length; i++) {
+            duplicates[i].property("Transform").property("Position").expression = exp;
+        }
+
+        // Apply to original layer too
+        sourceLayer.property("Transform").property("Position").expression = exp;
+    }
+
+    // ========== USER FEEDBACK ==========
+
+    function showResults(result, controllerCreated) {
+        var msg = "Recursive Scale Tunnel Complete!\n\n";
+        msg += "Duplicates created: " + result.count + "\n";
+        msg += "Scale range: " + Math.round(result.smallestScale * 100) / 100 + "% to " + Math.round(result.largestScale * 100) / 100 + "%\n";
+
+        if (controllerCreated) {
+            msg += 'Offset controller: "' + CTRL_NAME + '" (top of stack)\n';
+        }
+
+        alert(msg);
+    }
+
+    // ========== MAIN FUNCTION ==========
+
+    function main() {
+        var comp = app.project.activeItem;
+
+        if (!(comp instanceof CompItem)) {
+            alert("Please select a composition.");
+            return;
+        }
+
+        // Require exactly one selected layer
+        if (comp.selectedLayers.length === 0) {
+            alert("Please select a layer.");
+            return;
+        }
+
+        if (comp.selectedLayers.length > 1) {
+            alert("Please select a single layer.\nThis script operates on one layer at a time.");
+            return;
+        }
+
+        var sourceLayer = comp.selectedLayers[0];
+
+        if (!isResizableLayer(sourceLayer)) {
+            alert(
+                "Selected layer cannot be used.\n\n" +
+                "The layer must be an unlocked video layer with a source\n" +
+                "(footage, composition, or solid).\n\n" +
+                "Shape layers, text layers, nulls, cameras, lights,\n" +
+                "adjustment layers, and locked layers are not supported."
+            );
+            return;
+        }
+
+        // Warn about scale keyframes
+        if (hasScaleKeyframes(sourceLayer)) {
+            var continueKf = confirm(
+                "The selected layer has scale keyframes.\n\n" +
+                "The tunnel will be based on the current scale value\n" +
+                "and duplicates will have static scale. Continue?"
+            );
+            if (!continueKf) return;
+        }
+
+        var settings = showDialog();
+        if (settings === null) return;
+
+        // Check for existing tunnel layers
+        var existing = getExistingTunnelLayers(comp);
+        if (existing.length > 0) {
+            var replaceOk = confirm(
+                "Found " + existing.length + " existing tunnel layer(s).\n\nReplace them?"
+            );
+            if (!replaceOk) return;
+            removeExistingTunnelLayers(comp, sourceLayer);
+        }
+
+        var result = createTunnel(comp, sourceLayer, settings);
+        if (result === null) return;
+
+        var controllerCreated = false;
+        if (settings.createController) {
+            createControllerNull(comp, sourceLayer, result.duplicates);
+            controllerCreated = true;
+        }
+
+        showResults(result, controllerCreated);
+    }
+
+    // ========== EXECUTE ==========
+
+    app.beginUndoGroup("Recursive Scale Tunnel");
+    try {
+        main();
+    } catch (e) {
+        alert("Script error: " + e.message);
+    }
+    app.endUndoGroup();
+
+})();

--- a/ae/recursive_scale_tunnel.jsx
+++ b/ae/recursive_scale_tunnel.jsx
@@ -25,6 +25,12 @@
         return n;
     }
 
+    function parseInteger(value) {
+        var n = parseInt(value, 10);
+        if (isNaN(n)) return null;
+        return n;
+    }
+
     function zeroPad(num, digits) {
         var s = String(num);
         while (s.length < digits) {
@@ -84,6 +90,12 @@
 
         var ctrlCheck = dlg.add("checkbox", undefined, "Create offset controller null");
 
+        dlg.add("statictext", undefined, "Time offset per step (frames):");
+        var timeOffsetGroup = dlg.add("group");
+        var timeOffsetInput = timeOffsetGroup.add("edittext", undefined, "0");
+        timeOffsetInput.characters = 6;
+        timeOffsetGroup.add("statictext", undefined, "(0 = none, cumulative per duplicate)");
+
         var btnGroup = dlg.add("group");
         var okBtn = btnGroup.add("button", undefined, "Apply");
         var cancelBtn = btnGroup.add("button", undefined, "Cancel");
@@ -109,11 +121,18 @@
             return null;
         }
 
+        var timeOffset = parseInteger(timeOffsetInput.text);
+        if (timeOffset === null) {
+            alert("Please enter a whole number for time offset (0 for none).");
+            return null;
+        }
+
         return {
             step: step,
             minSize: minSize,
             useWidth: matchWidth.value,
-            createController: ctrlCheck.value
+            createController: ctrlCheck.value,
+            timeOffsetFrames: timeOffset
         };
     }
 
@@ -159,7 +178,7 @@
         };
     }
 
-    function createTunnel(comp, sourceLayer, settings) {
+    function createTunnel(comp, sourceLayer, settings, frameRate) {
         var dimInfo = getRenderedDimension(sourceLayer, settings.useWidth);
         var renderedDim = dimInfo.rendered;
         var sourceDim = dimInfo.sourceDim;
@@ -218,6 +237,12 @@
             }
 
             dup.name = NAME_PREFIX + baseName + " " + zeroPad(i, padDigits);
+
+            // Apply cumulative time offset (i = duplicate number from original)
+            if (settings.timeOffsetFrames !== 0) {
+                dup.startTime += (i * settings.timeOffsetFrames) / frameRate;
+            }
+
             duplicates.push(dup);
         }
 
@@ -225,7 +250,8 @@
             duplicates: duplicates,
             count: count,
             smallestScale: ((renderedDim - count * settings.step) / sourceDim) * 100,
-            largestScale: ((renderedDim - settings.step) / sourceDim) * 100
+            largestScale: ((renderedDim - settings.step) / sourceDim) * 100,
+            timeOffsetFrames: settings.timeOffsetFrames
         };
     }
 
@@ -261,6 +287,12 @@
         var msg = "Recursive Scale Tunnel Complete!\n\n";
         msg += "Duplicates created: " + result.count + "\n";
         msg += "Scale range: " + Math.round(result.smallestScale * 100) / 100 + "% to " + Math.round(result.largestScale * 100) / 100 + "%\n";
+
+        if (result.timeOffsetFrames !== 0) {
+            var dir = result.timeOffsetFrames > 0 ? "forward" : "backward";
+            var totalFrames = Math.abs(result.timeOffsetFrames * result.count);
+            msg += "Time offset: " + Math.abs(result.timeOffsetFrames) + "f per step " + dir + " (" + totalFrames + "f total)\n";
+        }
 
         if (controllerCreated) {
             msg += 'Offset controller: "' + CTRL_NAME + '" (top of stack)\n';
@@ -326,7 +358,7 @@
             removeExistingTunnelLayers(comp, sourceLayer);
         }
 
-        var result = createTunnel(comp, sourceLayer, settings);
+        var result = createTunnel(comp, sourceLayer, settings, comp.frameRate);
         if (result === null) return;
 
         var controllerCreated = false;

--- a/docs/brainstorms/2026-02-22-ae-recursive-scale-tunnel-brainstorm.md
+++ b/docs/brainstorms/2026-02-22-ae-recursive-scale-tunnel-brainstorm.md
@@ -1,0 +1,95 @@
+# Brainstorm: Recursive Scale Tunnel Effect for After Effects
+
+**Date:** 2026-02-22
+**Status:** Draft
+**App:** After Effects
+
+## What We're Building
+
+An After Effects script that takes a single selected layer, duplicates it repeatedly at progressively smaller scales, creating a tunnel/zoom effect. Each duplicate is a fixed number of pixels smaller on the chosen dimension (width or height) than the previous one. The loop stops when the next duplicate would be smaller than a user-defined minimum size.
+
+### Core Behavior
+
+1. User selects a single layer in the active composition
+2. Dialog collects parameters: pixel step, minimum size, dimension (width/height)
+3. Script duplicates the layer, scales it down by the step amount, and repeats
+4. Duplicates are centered (default tunnel look) with smallest layers on top of the stack
+5. Optionally creates a controller null that all duplicates link their position to, enabling animated offset
+
+### Dialog Inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| Step size | Number (pixels) | 100 | How many pixels smaller each duplicate is on the reference dimension |
+| Minimum size | Number (pixels) | 240 | Stop when next duplicate would be smaller than this |
+| Dimension | Radio (Width / Height) | Width | Which dimension to measure for stepping and minimum |
+| Create offset controller | Checkbox | Unchecked | Creates a null layer that all duplicates link position to |
+
+### Scaling Math
+
+Given a layer with source width `W` and current scale `S%`:
+- Current rendered width = `W * S / 100`
+- Each duplicate reduces the rendered dimension by `step` pixels
+- New scale for duplicate N = `((renderedDim - N * step) / sourceDim) * 100`
+- Stop when `renderedDim - N * step < minSize`
+
+Example: 1920px wide layer, step=100px, min=240px
+- Original: 1920px (100%)
+- Dup 1: 1820px (94.79%)
+- Dup 2: 1720px (89.58%)
+- ...
+- Dup 16: 320px (16.67%)
+- Dup 17: 220px -- below 240px minimum, stop at 16 duplicates
+
+### Layer Stacking
+
+- Smallest duplicate at the top of the layer stack (index 1 direction)
+- Creates a "looking into the tunnel" effect where smaller layers appear in front
+- All duplicates positioned at comp center (anchor point centered)
+
+### Controller Null (Optional)
+
+- When enabled, creates a null layer named "Tunnel Offset Controller"
+- Each duplicate gets a position expression: `thisComp.layer("Tunnel Offset Controller").transform.position`
+- Uniform offset: all duplicates shift by the same amount regardless of scale
+- User can then keyframe the null or apply expressions (wiggle, circular motion, etc.) to animate the entire tunnel
+
+## Why This Approach
+
+**Fixed pixel step over percentage step**: A fixed pixel decrement produces evenly-spaced visual layers in the tunnel, which looks more uniform. Percentage-based stepping would create layers that bunch up near the center (diminishing returns). The user explicitly chose pixel-based stepping.
+
+**Individual layers over pre-comp**: Keeps duplicates editable in the main comp. User can adjust individual layer properties, add effects per layer, or delete specific duplicates.
+
+**Controller null over per-layer expressions**: Clean separation of concerns. One control point for offset animation. Easy to delete or replace. Doesn't pollute each layer with complex expressions.
+
+**Uniform offset over parallax**: Simpler to reason about. User can add parallax later by modifying the expression to factor in scale if desired.
+
+## Key Decisions
+
+1. **Fixed pixel step** - each duplicate is N pixels smaller, not a percentage
+2. **Width or height reference** - user picks which dimension drives the stepping logic
+3. **Smallest on top** - layer stack order has smallest (frontmost) at the top
+4. **Single layer input** - operates on exactly one selected layer
+5. **Individual layers in comp** - no pre-composition of results
+6. **Controller null for offset** - optional, links all duplicate positions uniformly
+7. **Center-aligned by default** - duplicates inherit the original layer's position (comp center)
+
+## Open Questions
+
+None - all questions resolved during brainstorming.
+
+## Scope Boundaries
+
+**In scope:**
+- Dialog UI with the four inputs described above
+- Duplicate-and-scale loop with pixel stepping
+- Layer ordering (smallest on top)
+- Optional controller null with position expression
+
+**Out of scope (for now):**
+- Parallax/depth-scaled offset
+- Percentage-based step mode
+- Multiple selected layers
+- Pre-composition of results
+- Opacity fade on smaller duplicates
+- Per-duplicate color/effect variation

--- a/docs/plans/2026-02-22-feat-recursive-scale-tunnel-effect-plan.md
+++ b/docs/plans/2026-02-22-feat-recursive-scale-tunnel-effect-plan.md
@@ -1,0 +1,172 @@
+---
+title: "feat: Recursive Scale Tunnel Effect"
+type: feat
+status: completed
+date: 2026-02-22
+origin: docs/brainstorms/2026-02-22-ae-recursive-scale-tunnel-brainstorm.md
+---
+
+# feat: Recursive Scale Tunnel Effect
+
+## Overview
+
+An After Effects script that takes a single selected layer and creates a tunnel/zoom effect by duplicating it at progressively smaller scales. Each duplicate is a fixed number of pixels smaller on the chosen dimension (width or height). An optional controller null enables animated offset of the entire tunnel.
+
+## Problem Statement / Motivation
+
+Creating a tunnel or recursive zoom effect in After Effects is tedious manual work: duplicate a layer, calculate the scale, position it, repeat dozens of times. This script automates the entire process with a single dialog, producing consistent results in seconds. The optional controller null gives the user keyframeable or expression-driven animation of the tunnel's position without manually linking layers.
+
+## Proposed Solution
+
+A single vanilla ExtendScript file (`ae/recursive_scale_tunnel.jsx`) following the established repo patterns: IIFE wrapper, `#target aftereffects`, ScriptUI dialog, undo group, try/catch error handling, results alert.
+
+### Script Flow
+
+1. Validate: active composition, single selected layer, layer is resizable (AVLayer with source)
+2. Show dialog: step size (px), minimum size (px), dimension (width/height), controller null (checkbox)
+3. Calculate rendered dimension from source dimension and current scale
+4. Calculate duplicate count: `floor((renderedDim - minSize) / step)`
+5. If count is 0, alert and exit
+6. If count > 50, confirm dialog before proceeding (performance warning)
+7. Check for existing tunnel layers (by name prefix) and prompt for replacement
+8. Create duplicates in smallest-to-largest order (so smallest ends up on top of stack)
+9. Set scale on each duplicate: `((renderedDim - i * step) / sourceDim) * 100`
+10. Name duplicates with prefix: `RST__[OriginalName] 01`, `RST__[OriginalName] 02`, etc.
+11. If controller checkbox is on: create null, apply offset expression to all duplicates AND the original
+12. Show results alert
+
+### File
+
+- `ae/recursive_scale_tunnel.jsx` — single new file
+
+## Technical Considerations
+
+### Scaling Math
+
+The script must account for layers that are not at 100% scale. Use the **rendered dimension**, not source dimension, as the starting point:
+
+```
+renderedDim = sourceDim * currentScale / 100
+```
+
+For non-uniform scale (e.g., `[120, 80]`), use the scale axis that matches the user's dimension choice: `scaleX` for width, `scaleY` for height. Duplicates are set to uniform scale based on the calculated percentage.
+
+For 3D layers, check `layer.threeDLayer` and use `[pct, pct, pct]` instead of `[pct, pct]` for the Scale value.
+
+Read `Scale.value` (current time indicator), matching what the user sees in the viewport.
+
+### Controller Null Expression (Critical)
+
+The expression must be an **offset**, not a direct position replacement. A direct replacement (`thisComp.layer("Tunnel Offset Controller").transform.position`) would collapse all duplicates to the same point, destroying the tunnel layout.
+
+Correct expression:
+
+```javascript
+var ctrl = thisComp.layer("Tunnel Offset Controller");
+var offset = ctrl.transform.position - [thisComp.width/2, thisComp.height/2];
+value + offset;
+```
+
+When the null is at comp center (its default position), the offset is `[0, 0]` and duplicates stay in place. When the null moves, all layers shift uniformly. The null's default position is set to `[comp.width/2, comp.height/2]` on creation.
+
+Apply this expression to **both duplicates and the original layer** so the entire tunnel moves together.
+
+The controller null is placed at the top of the layer stack (index 1 direction) for easy access.
+
+### Layer Ordering
+
+`layer.duplicate()` places the copy directly above the source layer. If we always duplicate from the original layer, each new duplicate appears just above the original while previous duplicates remain higher in the stack:
+
+- Trace: original at index N → dup1 at N, original at N+1 → dup2 at N+1, original at N+2 → ...
+- Result: dup1 (created first) at top, dup_last (created last) just above original
+
+To get smallest on top, create the **smallest duplicate first** (loop from `i = maxCount` down to `i = 1`). This way the first-created (smallest) layer ends up highest in the stack.
+
+### Layer Type Validation
+
+Only accept AVLayer instances with a valid source. Guard using the existing `isResizableLayer` pattern from `resize_layers.jsx`:
+- Reject: locked, null, adjustment, camera, light, shape, text layers
+- Reject: layers without `.source.width`
+
+### Re-Run Safety
+
+Use a name prefix `RST__` (Recursive Scale Tunnel) on all generated layers. On re-run, detect existing `RST__` layers and prompt the user: "Previous tunnel layers found. Replace them?" Following the pattern from `wallpaper_pattern_loop.jsx` (lines 683-692).
+
+### Parenting
+
+Duplicates inherit the original layer's parent. This is acceptable for the default tunnel effect. The spec does not require special parenting behavior.
+
+### Existing Scale Keyframes
+
+If the original layer has scale keyframes, warn the user: the tunnel will be based on the scale at the current time indicator and duplicates will have static scale values. Duplicates do not inherit keyframes from `setValue()`.
+
+### Performance
+
+Follow the `wallpaper_pattern_loop.jsx` pattern: if duplicate count exceeds 50, show a confirmation dialog before proceeding. For very large counts, AE may become unresponsive.
+
+## Acceptance Criteria
+
+- [x] Script runs from File > Scripts > Run Script File in After Effects
+- [x] Dialog appears with: step size input, minimum size input, width/height radio buttons, controller null checkbox
+- [x] Validates single selected layer is an AVLayer with a valid source
+- [x] Correctly calculates rendered dimension accounting for current layer scale
+- [x] Creates the correct number of duplicates based on step and minimum size
+- [x] Each duplicate has the correct uniform scale value
+- [x] Layer stack order: smallest duplicate on top, original at bottom of tunnel group
+- [x] Duplicates named with `RST__` prefix and zero-padded index
+- [x] Controller null (when enabled) is created at comp center, placed at top of stack
+- [x] Controller null expression is an offset (not direct position), applied to duplicates AND original
+- [x] Moving the controller null shifts the entire tunnel uniformly
+- [x] 3D layers supported with 3-value scale array
+- [x] Zero duplicates case shows a clear alert message
+- [x] Large duplicate count (>50) triggers a confirmation dialog
+- [x] Re-run detects existing `RST__` layers and prompts for replacement
+- [x] Entire operation is wrapped in a single undo group
+- [x] Results alert shows: duplicate count, scale range, controller status
+
+## Success Metrics
+
+- Tunnel effect is visually correct: concentric layers decreasing in size toward center
+- Single Cmd+Z undoes the entire operation
+- Controller null animates the full tunnel as expected
+
+## Dependencies & Risks
+
+- **No external dependencies** — vanilla ExtendScript, no library includes
+- **Risk: AE performance** — mitigated by the 50-duplicate confirmation threshold
+- **Risk: Expression errors** — if the user renames the controller null, expressions break. Mitigated by using a clear, distinctive name
+
+## Implementation Sections
+
+The script follows the established repo structure:
+
+```
+// ========== UTILITY FUNCTIONS ==========
+// isResizableLayer(), parsePositiveFloat(), parsePositiveInt()
+
+// ========== DIALOG ==========
+// showDialog() — returns settings object or null
+
+// ========== CORE FUNCTIONS ==========
+// getExistingTunnelLayers(), removeExistingTunnelLayers()
+// calculateDuplicateCount(), createTunnel(), createControllerNull()
+
+// ========== USER FEEDBACK ==========
+// showResults()
+
+// ========== MAIN FUNCTION ==========
+// main() — orchestrates validation, dialog, creation, feedback
+
+// ========== EXECUTE ==========
+// app.beginUndoGroup() + try/catch + app.endUndoGroup()
+```
+
+## Sources & References
+
+- **Origin brainstorm:** [docs/brainstorms/2026-02-22-ae-recursive-scale-tunnel-brainstorm.md](docs/brainstorms/2026-02-22-ae-recursive-scale-tunnel-brainstorm.md) — key decisions: fixed pixel step, smallest on top, controller null for offset, single layer input, uniform offset
+- Similar patterns: `ae/resize_layers.jsx` (scale math, dialog, layer validation), `ae/wallpaper_pattern_loop.jsx` (re-run safety, expression application, performance warnings)
+- Scale manipulation: `ae/resize_layers.jsx:160`
+- Expression application: `ae/wallpaper_pattern_loop.jsx:643-662`
+- Re-run detection: `ae/wallpaper_pattern_loop.jsx:298-318, 683-692`
+- Input validation helpers: `ae/wallpaper_pattern_loop.jsx:29-45`
+- Layer type guard: `ae/resize_layers.jsx:15-32`


### PR DESCRIPTION
## Summary
- New AE script that creates a tunnel/zoom effect by duplicating a selected layer at progressively smaller scales
- Fixed pixel step control with width/height dimension choice
- Optional controller null ("Tunnel Offset Controller") with offset expression for animating the entire tunnel
- Re-run safety via `RST__` name prefix detection and replacement prompt
- 3D layer support, scale keyframe warnings, and performance guard (>50 duplicates)

## Test plan
- [ ] Open After Effects, create a composition with a footage layer
- [ ] Select the layer, run `ae/recursive_scale_tunnel.jsx` via File > Scripts
- [ ] Verify dialog shows step size, min size, width/height radio, controller checkbox
- [ ] Apply with defaults (step=100, min=240, width) and verify tunnel layers are created
- [ ] Verify smallest layer is on top of the stack
- [ ] Enable controller null checkbox, re-run — verify null appears at top, moving it shifts all layers
- [ ] Test re-run: run script again on the original layer, confirm replacement prompt works
- [ ] Test with a 3D layer to verify 3-axis scale
- [ ] Test edge case: step larger than available range — should show informative alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)