### PR TITLE
Fix tunnel controller null expression

### DIFF
--- a/ae/recursive_scale_tunnel.jsx
+++ b/ae/recursive_scale_tunnel.jsx
@@ -265,12 +265,9 @@
         // Move to top of layer stack
         ctrl.moveTo(1);
 
-        // Build offset expression
-        var exp = [
-            'var ctrl = thisComp.layer("' + CTRL_NAME + '");',
-            'var offset = ctrl.transform.position - [thisComp.width/2, thisComp.height/2];',
-            'value + offset;'
-        ].join("\n");
+        // Link position directly to controller — all tunnel layers share the same
+        // center point (they differ in scale, not position)
+        var exp = 'thisComp.layer("' + CTRL_NAME + '").transform.position';
 
         // Apply to all duplicates
         for (var i = 0; i < duplicates.length; i++) {


### PR DESCRIPTION
## Summary
- Fix controller null expression so moving the null actually moves all tunnel layers
- Changed from offset-delta calculation to direct position link
- All tunnel layers share the same center point (they differ in scale, not position), so the expression should directly set position to the null's position

## Test plan
- [ ] Run script with controller null enabled
- [ ] Move the null layer — all tunnel layers should follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)